### PR TITLE
Feature continue search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "pdpw"
-version = "0.6.14"
+version = "0.7.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3012,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "e7442a916bc70e3bf71a5305a899d53301649d2838345fa309420318b5ffafe8"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdpw"
-version = "0.6.14"
+version = "0.7.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you start pdpw without providing a *.pdpw file it will create a
 - `strg + s` encrypt and save changes to the *.pdpw file that you have opened.
   Typically `default.pdpw`
 - `strg + f` open the search dialog
+- `F3` continue search
 
 
 ## Configure Gnome Desktop integration

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+// #![windows_subsystem = "windows"]
 mod about;
 mod editor;
 mod galloc;


### PR DESCRIPTION
So far the search always started from the top of the document. So further hits could not be found.

With this change the search will start from the current cursor position.

Also with shortcut F3 search will can be continued to the next hit.

However search will not wrap at the end of the document. One still has to move the cursor to the start of the document to continue search from the beginning.